### PR TITLE
DRAFT coreboot-utils: update refspecs after coreboot rebase

### DIFF
--- a/meta-dts-distro/recipes-bsp/coreboot-utils/cbfstool_git.bb
+++ b/meta-dts-distro/recipes-bsp/coreboot-utils/cbfstool_git.bb
@@ -1,7 +1,7 @@
 require coreboot-utils.inc
 
 SRC_URI += " \
-    file://0001-.gitmodules-Switch-to-HTTPS-links.patch \
+    file://0001-.gitmodules-switch-to-HTTPS-links.patch \
 "
 
 TARGET_CC_ARCH += "${LDFLAGS}"

--- a/meta-dts-distro/recipes-bsp/coreboot-utils/coreboot-utils.inc
+++ b/meta-dts-distro/recipes-bsp/coreboot-utils/coreboot-utils.inc
@@ -6,9 +6,9 @@ LICENSE = "LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=751419260aa954499f7abaabaa882bbe"
 
 SRC_URI = " \
-    git://github.com/Dasharo/coreboot.git;protocol=https;branch=coreboot-utils \
+    git://github.com/Dasharo/coreboot.git;protocol=https;branch=utils-patches \
     "
 
-SRCREV = "3ab63163007c0be7c8d93948f29a409055cda66c"
+SRCREV = "1d1be231f152525fbe1740a77b361132c39b5be8"
 
 S = "${WORKDIR}/git"

--- a/meta-dts-distro/recipes-bsp/coreboot-utils/files/0001-.gitmodules-switch-to-HTTPS-links.patch
+++ b/meta-dts-distro/recipes-bsp/coreboot-utils/files/0001-.gitmodules-switch-to-HTTPS-links.patch
@@ -1,90 +1,101 @@
-From 1e9cd4b9b376dca74bf8f7e73c1bb8d6613370d2 Mon Sep 17 00:00:00 2001
-From: =?UTF-8?q?Micha=C5=82=20=C5=BBygowski?= <michal.zygowski@3mdeb.com>
-Date: Tue, 14 Jul 2020 17:38:56 +0200
-Subject: [PATCH] .gitmodules: Switch to HTTPS links
-MIME-Version: 1.0
-Content-Type: text/plain; charset=UTF-8
-Content-Transfer-Encoding: 8bit
+From fe9a23b40d2c1a683f9f032bf2e0ab749ae8dbd4 Mon Sep 17 00:00:00 2001
+From: Kas User <kas@example.com>
+Date: Tue, 29 Nov 2022 11:08:59 +0000
+Subject: [PATCH] .gitmodules: switch to HTTPS links
 
-Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>
 ---
- .gitmodules | 28 ++++++++++++++--------------
- 1 file changed, 14 insertions(+), 14 deletions(-)
+ .gitmodules | 34 +++++++++++++++++-----------------
+ 1 file changed, 17 insertions(+), 17 deletions(-)
 
 diff --git a/.gitmodules b/.gitmodules
-index 68230b92edf9..d629759a2827 100644
+index 6f62952f435..391c71b794a 100644
 --- a/.gitmodules
 +++ b/.gitmodules
-@@ -1,56 +1,56 @@
+@@ -1,67 +1,67 @@
  [submodule "3rdparty/blobs"]
  	path = 3rdparty/blobs
 -	url = ../blobs.git
-+	url = https://review.coreboot.org//blobs.git
++	url = https://review.coreboot.org/blobs.git
  	update = none
  	ignore = dirty
  [submodule "util/nvidia-cbootimage"]
  	path = util/nvidia/cbootimage
 -	url = ../nvidia-cbootimage.git
-+	url = https://review.coreboot.org//nvidia-cbootimage.git
++	url = https://review.coreboot.org/nvidia-cbootimage.git
  [submodule "vboot"]
  	path = 3rdparty/vboot
 -	url = ../vboot.git
-+	url = https://review.coreboot.org//vboot.git
++	url = https://review.coreboot.org/vboot.git
  	branch = main
  [submodule "arm-trusted-firmware"]
  	path = 3rdparty/arm-trusted-firmware
 -	url = ../arm-trusted-firmware.git
-+	url = https://review.coreboot.org//arm-trusted-firmware.git
++	url = https://review.coreboot.org/arm-trusted-firmware.git
  [submodule "3rdparty/chromeec"]
  	path = 3rdparty/chromeec
 -	url = ../chrome-ec.git
-+	url = https://review.coreboot.org//chrome-ec.git
++	url = https://review.coreboot.org/chrome-ec.git
  [submodule "libhwbase"]
  	path = 3rdparty/libhwbase
 -	url = ../libhwbase.git
-+	url = https://review.coreboot.org//libhwbase.git
++	url = https://review.coreboot.org/libhwbase.git
  [submodule "libgfxinit"]
  	path = 3rdparty/libgfxinit
 -	url = ../libgfxinit.git
-+	url = https://review.coreboot.org//libgfxinit.git
++	url = https://review.coreboot.org/libgfxinit.git
  [submodule "3rdparty/fsp"]
  	path = 3rdparty/fsp
 -	url = ../fsp.git
-+	url = https://review.coreboot.org//fsp.git
++	url = https://review.coreboot.org/fsp.git
  	update = none
  	ignore = dirty
  [submodule "opensbi"]
  	path = 3rdparty/opensbi
 -	url = ../opensbi.git
-+	url = https://review.coreboot.org//opensbi.git
++	url = https://review.coreboot.org/opensbi.git
  [submodule "intel-microcode"]
  	path = 3rdparty/intel-microcode
 -	url = ../intel-microcode.git
-+	url = https://review.coreboot.org//intel-microcode.git
++	url = https://review.coreboot.org/intel-microcode.git
  	update = none
  	ignore = dirty
  	branch = main
  [submodule "3rdparty/ffs"]
  	path = 3rdparty/ffs
 -	url = ../ffs.git
-+	url = https://review.coreboot.org//ffs.git
++	url = https://review.coreboot.org/ffs.git
  [submodule "3rdparty/amd_blobs"]
  	path = 3rdparty/amd_blobs
 -	url = ../amd_blobs
-+	url = https://review.coreboot.org//amd_blobs
++	url = https://review.coreboot.org/amd_blobs
  	update = none
  	ignore = dirty
  [submodule "3rdparty/cmocka"]
  	path = 3rdparty/cmocka
 -	url = ../cmocka.git
-+	url = https://review.coreboot.org//cmocka.git
++	url = https://review.coreboot.org/cmocka.git
  	update = none
+ 	branch = stable-1.1
  [submodule "3rdparty/qc_blobs"]
  	path = 3rdparty/qc_blobs
 -	url = ../qc_blobs.git
-+	url = https://review.coreboot.org//qc_blobs.git
++	url = https://review.coreboot.org/qc_blobs.git
  	update = none
  	ignore = dirty
  [submodule "3rdparty/intel-sec-tools"]
+ 	path = 3rdparty/intel-sec-tools
+-	url = ../9esec-security-tooling.git
++	url = https://review.coreboot.org/9esec-security-tooling.git
+ [submodule "3rdparty/stm"]
+ 	path = 3rdparty/stm
+-	url = ../STM
++	url = https://review.coreboot.org/STM
+ 	branch = stmpe
+ [submodule "util/goswid"]
+ 	path = util/goswid
+-	url = ../goswid
++	url = https://review.coreboot.org/goswid
+ 	branch = trunk
 -- 
-2.25.1
+2.20.1
+

--- a/meta-dts-distro/recipes-bsp/coreboot-utils/intelp2m_git.bb
+++ b/meta-dts-distro/recipes-bsp/coreboot-utils/intelp2m_git.bb
@@ -7,7 +7,7 @@ GO_IMPORT = "github.com/dasharo/coreboot/"
 # we need to override SRC_URI from coreboot-utils.inc so it's unpacked in the
 # directory as expected by the go bbclass
 SRC_URI = " \
-    git://github.com/Dasharo/coreboot.git;protocol=https;branch=coreboot-utils;destsuffix=${GO_IMPORT} \
+    git://github.com/Dasharo/coreboot.git;protocol=https;branch=utils-patches;destsuffix=${GO_IMPORT} \
     "
 
 S = "${WORKDIR}/${GO_IMPORT}/util/intelp2m"
@@ -16,13 +16,7 @@ inherit goarch
 inherit go
 
 do_compile() {
-    export GOARCH="${TARGET_GOARCH}"
-    export GOPATH="${WORKDIR}/git/"
-
-    export GO111MODULE=off
-
     cd ${S}
-
     oe_runmake
 }
 


### PR DESCRIPTION
We can wait for these changes for now and update refspecs if utils patches will be merged into mainline coreboot