### PR TITLE
Autoboot script passed by iPXE shell

### DIFF
--- a/meta-dts-distro/recipes-dts/packagegroups/packagegroup-dts.bb
+++ b/meta-dts-distro/recipes-dts/packagegroups/packagegroup-dts.bb
@@ -21,6 +21,7 @@ RDEPENDS:${PN}-system = " \
     chronyc \
     gnupg \
     wget \
+    ipxe-commands \
 "
 
 RDEPENDS:${PN}-tests = " \

--- a/meta-dts-distro/recipes-support/ipxe-commands/files/ipxe-commands.service
+++ b/meta-dts-distro/recipes-support/ipxe-commands/files/ipxe-commands.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=iPXE commands autostart on boot
+ConditionPathExists=/sbin/ipxe-commands
+
+[Service]
+Type=simple
+ExecStart=/bin/bash /sbin/ipxe-commands
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-dts-distro/recipes-support/ipxe-commands/ipxe-commands_local.bb
+++ b/meta-dts-distro/recipes-support/ipxe-commands/ipxe-commands_local.bb
@@ -1,0 +1,26 @@
+DESCRIPTION = "iPXE commands autostart on boot"
+HOMEPAGE = "https://github.com/Dasharo/meta-dts"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+SRC_URI = "file://ipxe-commands.service"
+
+S = "${WORKDIR}"
+
+do_install () {
+    install -m 0755 -d ${D}${systemd_unitdir}/system
+    install -m 0644 ${S}/ipxe-commands.service ${D}${systemd_unitdir}/system/
+}
+
+SYSTEMD_SERVICE:${PN} = " \
+    ipxe-commands.service \
+    "
+
+SYSTEMD_PACKAGES = " \
+    ${PN} \
+    "
+
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+inherit systemd


### PR DESCRIPTION
### Description

This PR introduce `systemd` service that will execute on boot `ipxe-command` if exists. It can be used to pass and execute linux commands from ipxe shell.

### Evidence and reproduce instructions

Service status if `/sbin/ipxe-command` script doesn't exist:
```
# systemctl status ipxe-commands
* ipxe-commands.service - iPXE commands autostart on boot
     Loaded: loaded (8;;file://DasharoToolsSuite/lib/systemd/system/ipxe-commands.service/lib/systemd/system/ipxe-commands.service8;;; enabled; vendor8;;>
     Active: inactive (dead)
  Condition: start condition failed at Mon 2023-01-16 14:08:17 UTC; 23s ago
             `- ConditionPathExists=/sbin/ipxe-commands was not met
```
---

You will need to create script file with `dts.ipxe` boot menu in folder with DTS binaries (in default configuration it should be ` build/tmp/deploy/images/genericx86-64`). Example content of `dts.ipxe` menu:
```
#!ipxe
#
kernel http://192.168.1.1:9000/bzImage root=/dev/nfs initrd=http://192.168.1.1:9001/dts-base-image-genericx86-64.cpio.gz
initrd http://192.168.1.1:9000/dts-base-image-genericx86-64.cpio.gz
module http://192.168.1.1:9000/ipxe-commands /sbin/ipxe-commands mode=755
boot
```
From that localization, run simple HTTP server

```
$ python3 -m http.server 9000
```

Boot your device to iPXE shell and run these commands:

```
iPXE> dhcp                               
Configuring (net0 00:0d:b9:4b:49:60)...... ok
iPXE> route
net0: 192.168.4.126/255.255.255.0 gw 192.168.4.1
iPXE> chain http://192.168.4.98:9001/dts.ipxe
http://192.168.4.98:9001/dts.ipxe... ok
http://192.168.4.98:9001/bzImage... ok
http://192.168.4.98:9001/dts-base-image-genericx86-64.cpio.gz... ok
http://192.168.4.98:9000/ipxe-commands... ok
```

Now DTS should boot and start `/sbin/ipxe-commands` script automatically

```
# systemctl status ipxe-commands
* ipxe-commands.service - iPXE commands autostart on boot
     Loaded: loaded (8;;file://DasharoToolsSuite/lib/systemd/system/ipxe-commands.service/lib/systemd/system/ipxe-commands.service8;;; enabled; vendor8;;>
     Active: inactive (dead) since Mon 2023-01-16 14:32:48 UTC; 17s ago
    Process: 237 ExecStart=/bin/bash /sbin/ipxe-commands (code=exited, status=0>
   Main PID: 237 (code=exited, status=0/SUCCESS)

Jan 16 14:32:48 DasharoToolsSuite systemd[1]: Started iPXE commands autostart o>
Jan 16 14:32:48 DasharoToolsSuite systemd[1]: ipxe-commands.service: Deactivate>
```

### Related changes

N/A 

### Known issues

N/A