### PR TITLE
dts/dts-functions.sh: fix updating boards without Vboot slot B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the DTS project will be documented in this file.
 
+## v1.2.12 - 2023-11-03
+
+* Fix updating boards without Vboot slot B
+
 ## v1.2.11 - 2023-10-31
 
 * Bumped supported firmware versions of NovaCustom to 1.5.1/1.7.1

--- a/meta-dts-distro/conf/distro/dts-distro.conf
+++ b/meta-dts-distro/conf/distro/dts-distro.conf
@@ -4,7 +4,7 @@ DISTRO = "dts-distro"
 
 # distro name
 DISTRO_NAME = "Dasharo Tools Suite"
-DISTRO_VERSION = "1.2.11"
+DISTRO_VERSION = "1.2.12"
 SDK_VENDOR = "-dtssdk"
 
 MAINTAINER = "3mdeb Sp. z o. o. <contact@3mdeb.com>"

--- a/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
+++ b/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
@@ -140,7 +140,7 @@ board_config() {
               FLASHROM_ADD_OPT_UPDATE="--ifd -i bios"
             else
               # For Dasharo version greater or equal 1.5.0
-              FLASHROM_ADD_OPT_UPDATE="--fmap -i RW_SECTION_A -i RW_SECTION_B"
+              FLASHROM_ADD_OPT_UPDATE="--fmap -i RW_SECTION_A"
             fi
           fi
           ;;
@@ -169,7 +169,7 @@ board_config() {
               FLASHROM_ADD_OPT_UPDATE="--ifd -i bios"
             else
               # For Dasharo version greater or equal 1.5.0
-              FLASHROM_ADD_OPT_UPDATE="--fmap -i RW_SECTION_A -i RW_SECTION_B"
+              FLASHROM_ADD_OPT_UPDATE="--fmap -i RW_SECTION_A"
             fi
           fi
           ;;
@@ -198,7 +198,7 @@ board_config() {
               FLASHROM_ADD_OPT_UPDATE="--ifd -i bios"
             else
               # For Dasharo version greater or equal 1.7.0
-              FLASHROM_ADD_OPT_UPDATE="--fmap -i RW_SECTION_A -i RW_SECTION_B"
+              FLASHROM_ADD_OPT_UPDATE="--fmap -i RW_SECTION_A"
             fi
           fi
           ;;
@@ -227,7 +227,7 @@ board_config() {
               FLASHROM_ADD_OPT_UPDATE="--ifd -i bios"
             else
               # For Dasharo version greater or equal 1.7.0
-              FLASHROM_ADD_OPT_UPDATE="--fmap -i RW_SECTION_A -i RW_SECTION_B"
+              FLASHROM_ADD_OPT_UPDATE="--fmap -i RW_SECTION_A"
             fi
           fi
           ;;


### PR DESCRIPTION
Fixes updating from v1.5.0 to v1.5.1 and v1.7.0 to v1.7.1
