### PR TITLE
scripts/generate-ipxe-menu.sh: more readable script, prepare for imgverify

### DIFF
--- a/scripts/generate-ipxe-menu.sh
+++ b/scripts/generate-ipxe-menu.sh
@@ -3,8 +3,32 @@
 VERSION=$1
 IPXE_FILE="dts.ipxe"
 
-echo "#!ipxe" > ${IPXE_FILE}
-echo "#" >> ${IPXE_FILE}
-echo "kernel http://boot.dasharo.com/dts/${VERSION}/bzImage-${VERSION} root=/dev/nfs initrd=dts-base-image-${VERSION}.cpio.gz" >> ${IPXE_FILE}
-echo "initrd http://boot.dasharo.com/dts/${VERSION}/dts-base-image-${VERSION}.cpio.gz" >> ${IPXE_FILE}
-echo "boot" >> ${IPXE_FILE}
+if [ $# -ne 1 ]; then
+  echo "Provide version, e.g. v1.2.3"
+  exit
+fi
+
+# imgverify can be enabled as a next step on top of the HTTPS. The imgtrust
+# should already be executed in the embedded script on the device. Also, we
+# should gracefuly handle older firmware versions, where imgtrust and imgverify
+# command could not be yet available.
+# imgtrust --permanent
+#
+# set sig_kernel ${path_kernel}.sig
+# set sig_initrd ${path_initrd}.sig
+# imgverify file_kernel \${sig_kernel}
+# imgverify file_initrd \${sig_initrd}
+
+cat <<EOF > "${IPXE_FILE}"
+#!ipxe
+set dts_version ${VERSION}
+set dts_prefix \${dts_version}
+set path_kernel \${dts_prefix}/bzImage-\${dts_version}
+set path_initrd \${dts_prefix}/dts-base-image-\${dts_version}.cpio.gz
+
+imgfetch --name file_kernel \${path_kernel}
+imgfetch --name file_initrd \${path_initrd}
+
+kernel file_kernel root=/dev/nfs initrd=file_initrd
+boot
+EOF


### PR DESCRIPTION
The imgverify will probably will not be added in this iteration. We will still need to create our signing certificate and also create script in such a way that it handles correctly devices whete such command is not present.

Tested on: https://boot.dasharo.com/dts/dtss.ipxe