### PR TITLE
dasharo-deploy: update smmstore and bootsplash migration console output

### DIFF
--- a/meta-dts-distro/recipes-dts/dts/dasharo-deploy/dasharo-deploy
+++ b/meta-dts-distro/recipes-dts/dts/dasharo-deploy/dasharo-deploy
@@ -226,24 +226,40 @@ smbios_migration() {
 }
 
 smmstore_migration() {
-    echo "Beginning SMMSTORE migration process..."
+    echo -n "Backing up firmware configuration... "
     flashrom -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} -r /tmp/dasharo_dump.rom ${FLASHROM_ADD_OPT_READ} --fmap -i FMAP -i SMMSTORE >> $FLASHROM_LOG_FILE 2>> $ERR_LOG_FILE
-    cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin
-    echo "Migrate to SMMSTORE section."
-    cbfstool "$BIOS_UPDATE_FILE" write -r SMMSTORE -f /tmp/smmstore.bin -u
+    cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin >> $ERR_LOG_FILE 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Failed! Default settings will be used."
+        return 1
+    fi
+    cbfstool "$BIOS_UPDATE_FILE" write -r SMMSTORE -f /tmp/smmstore.bin -u >> $ERR_LOG_FILE 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Failed! Default settings will be used."
+        return 1
+    fi
+    echo Done.
 }
 
 bootsplash_migration() {
-    echo "Beginning BOOTSPLASH migration process..."
     flashrom -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} -r /tmp/dasharo_dump.rom ${FLASHROM_ADD_OPT_READ} --fmap -i FMAP -i BOOTSPLASH >> $FLASHROM_LOG_FILE 2>> $ERR_LOG_FILE
     cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp >> $ERR_LOG_FILE 2>&1
     if [ $? -ne 0 ]; then
-      echo "logo.bmp not found, nothing to migrate"
-      return 1
+        # No logo, so exit early and don't show unnecessary messages
+        return 1
     fi
-    echo "Migrate logo.bmp to BOOTSPLASH section."
+    echo -n "Backing up custom boot logo... "
     cbfstool $BIOS_UPDATE_FILE remove -n logo.bmp -r BOOTSPLASH >> $ERR_LOG_FILE 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Failed! Default boot splash will be used."
+        return 1
+    fi
     cbfstool $BIOS_UPDATE_FILE add -f /tmp/logo.bmp -r BOOTSPLASH -n logo.bmp -t raw -c lzma >> $ERR_LOG_FILE 2>&1
+    if [ $? -ne 0 ]; then
+        echo "Failed! Default boot splash will be used."
+        return 1
+    fi
+    echo Done.
 }
 
 resign_binary() {

--- a/meta-dts-distro/recipes-dts/dts/dasharo-deploy/dasharo-deploy
+++ b/meta-dts-distro/recipes-dts/dts/dasharo-deploy/dasharo-deploy
@@ -226,7 +226,7 @@ smbios_migration() {
 }
 
 smmstore_migration() {
-    echo "Backing up firmware configuration... "
+    echo -n "Backing up firmware configuration... "
     flashrom -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} -r /tmp/dasharo_dump.rom ${FLASHROM_ADD_OPT_READ} --fmap -i FMAP -i SMMSTORE >> $FLASHROM_LOG_FILE 2>> $ERR_LOG_FILE
     cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin >> $ERR_LOG_FILE 2>&1 || \
       print_warning "Failed! Default settings will be used."
@@ -240,7 +240,7 @@ bootsplash_migration() {
     # If no custom logo, return from bootsplash_migration early and don't show
     # unnecessary messages
     cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp >> $ERR_LOG_FILE 2>&1 || return 1
-    echo "Backing up custom boot logo... "
+    echo -n "Backing up custom boot logo... "
     cbfstool $BIOS_UPDATE_FILE remove -n logo.bmp -r BOOTSPLASH >> $ERR_LOG_FILE 2>&1 || \
       print_warning "Failed! Default boot splash will be used."
     cbfstool $BIOS_UPDATE_FILE add -f /tmp/logo.bmp -r BOOTSPLASH -n logo.bmp -t raw -c lzma >> $ERR_LOG_FILE 2>&1 || \

--- a/meta-dts-distro/recipes-dts/dts/dasharo-deploy/dasharo-deploy
+++ b/meta-dts-distro/recipes-dts/dts/dasharo-deploy/dasharo-deploy
@@ -229,37 +229,22 @@ smmstore_migration() {
     echo -n "Backing up firmware configuration... "
     flashrom -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} -r /tmp/dasharo_dump.rom ${FLASHROM_ADD_OPT_READ} --fmap -i FMAP -i SMMSTORE >> $FLASHROM_LOG_FILE 2>> $ERR_LOG_FILE
     cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin >> $ERR_LOG_FILE 2>&1
-    if [ $? -ne 0 ]; then
-        echo "Failed! Default settings will be used."
-        return 1
-    fi
+    error_check "Failed! Default settings will be used."
     cbfstool "$BIOS_UPDATE_FILE" write -r SMMSTORE -f /tmp/smmstore.bin -u >> $ERR_LOG_FILE 2>&1
-    if [ $? -ne 0 ]; then
-        echo "Failed! Default settings will be used."
-        return 1
-    fi
-    echo Done.
+    error_check "Failed! Default settings will be used."
+    print_green Done.
 }
 
 bootsplash_migration() {
     flashrom -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} -r /tmp/dasharo_dump.rom ${FLASHROM_ADD_OPT_READ} --fmap -i FMAP -i BOOTSPLASH >> $FLASHROM_LOG_FILE 2>> $ERR_LOG_FILE
     cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp >> $ERR_LOG_FILE 2>&1
-    if [ $? -ne 0 ]; then
-        # No logo, so exit early and don't show unnecessary messages
-        return 1
-    fi
+    error_check # No custom logo, so exit early and don't show unnecessary messages
     echo -n "Backing up custom boot logo... "
     cbfstool $BIOS_UPDATE_FILE remove -n logo.bmp -r BOOTSPLASH >> $ERR_LOG_FILE 2>&1
-    if [ $? -ne 0 ]; then
-        echo "Failed! Default boot splash will be used."
-        return 1
-    fi
+    error_check "Failed! Default boot splash will be used."
     cbfstool $BIOS_UPDATE_FILE add -f /tmp/logo.bmp -r BOOTSPLASH -n logo.bmp -t raw -c lzma >> $ERR_LOG_FILE 2>&1
-    if [ $? -ne 0 ]; then
-        echo "Failed! Default boot splash will be used."
-        return 1
-    fi
-    echo Done.
+    error_check "Failed! Default boot splash will be used."
+    print_green Done.
 }
 
 resign_binary() {
@@ -417,10 +402,7 @@ update() {
   local _update_version=""
 
   check_if_ac
-  if [ $? -ne 0 ]; then
-    echo "Firmware update process interrupted on user request."
-    exit 1
-  fi
+  error_check "Firmware update process interrupted on user request."
 
   echo "Checking for the latest Dasharo update available..."
   echo "Current Dasharo version: $DASHARO_VERSION"

--- a/meta-dts-distro/recipes-dts/dts/dasharo-deploy/dasharo-deploy
+++ b/meta-dts-distro/recipes-dts/dts/dasharo-deploy/dasharo-deploy
@@ -226,24 +226,25 @@ smbios_migration() {
 }
 
 smmstore_migration() {
-    echo -n "Backing up firmware configuration... "
+    echo "Backing up firmware configuration... "
     flashrom -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} -r /tmp/dasharo_dump.rom ${FLASHROM_ADD_OPT_READ} --fmap -i FMAP -i SMMSTORE >> $FLASHROM_LOG_FILE 2>> $ERR_LOG_FILE
-    cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin >> $ERR_LOG_FILE 2>&1
-    error_check "Failed! Default settings will be used."
-    cbfstool "$BIOS_UPDATE_FILE" write -r SMMSTORE -f /tmp/smmstore.bin -u >> $ERR_LOG_FILE 2>&1
-    error_check "Failed! Default settings will be used."
+    cbfstool /tmp/dasharo_dump.rom read -r SMMSTORE -f /tmp/smmstore.bin >> $ERR_LOG_FILE 2>&1 || \
+      print_warning "Failed! Default settings will be used."
+    cbfstool "$BIOS_UPDATE_FILE" write -r SMMSTORE -f /tmp/smmstore.bin -u >> $ERR_LOG_FILE 2>&1 || \
+      print_warning "Failed! Default settings will be used."
     print_green Done.
 }
 
 bootsplash_migration() {
     flashrom -p "$PROGRAMMER_BIOS" ${FLASH_CHIP_SELECT} -r /tmp/dasharo_dump.rom ${FLASHROM_ADD_OPT_READ} --fmap -i FMAP -i BOOTSPLASH >> $FLASHROM_LOG_FILE 2>> $ERR_LOG_FILE
-    cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp >> $ERR_LOG_FILE 2>&1
-    error_check # No custom logo, so exit early and don't show unnecessary messages
-    echo -n "Backing up custom boot logo... "
-    cbfstool $BIOS_UPDATE_FILE remove -n logo.bmp -r BOOTSPLASH >> $ERR_LOG_FILE 2>&1
-    error_check "Failed! Default boot splash will be used."
-    cbfstool $BIOS_UPDATE_FILE add -f /tmp/logo.bmp -r BOOTSPLASH -n logo.bmp -t raw -c lzma >> $ERR_LOG_FILE 2>&1
-    error_check "Failed! Default boot splash will be used."
+    # If no custom logo, return from bootsplash_migration early and don't show
+    # unnecessary messages
+    cbfstool /tmp/dasharo_dump.rom extract -r BOOTSPLASH -n logo.bmp -f /tmp/logo.bmp >> $ERR_LOG_FILE 2>&1 || return 1
+    echo "Backing up custom boot logo... "
+    cbfstool $BIOS_UPDATE_FILE remove -n logo.bmp -r BOOTSPLASH >> $ERR_LOG_FILE 2>&1 || \
+      print_warning "Failed! Default boot splash will be used."
+    cbfstool $BIOS_UPDATE_FILE add -f /tmp/logo.bmp -r BOOTSPLASH -n logo.bmp -t raw -c lzma >> $ERR_LOG_FILE 2>&1 || \
+      print_warning "Failed! Default boot splash will be used."
     print_green Done.
 }
 

--- a/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
+++ b/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
@@ -648,7 +648,7 @@ compare_versions() {
 }
 
 download_artifacts() {
-  echo "Downloading Dasharo firmware..."
+  echo -n "Downloading Dasharo firmware..."
   if [ -v BIOS_LINK_COMM ] && [ ${BIOS_LINK} == ${BIOS_LINK_COMM} ]; then
     curl -s -L -f "$BIOS_LINK" -o $BIOS_UPDATE_FILE
     error_check "Cannot access $FW_STORE_URL while downloading binary. Please
@@ -693,6 +693,7 @@ download_artifacts() {
      check your internet connection"
     fi
   fi
+  print_green "Done"
 }
 
 download_keys() {
@@ -705,7 +706,7 @@ download_keys() {
 }
 
 get_signing_keys() {
-    echo "Getting platform specific GPG key... "
+    echo -n "Getting platform specific GPG key... "
     wget -q https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/master/$PLATFORM_SIGN_KEY -O - | gpg --import - >> $ERR_LOG_FILE 2>&1
     error_check "Cannot get platform specific key to verify signatures."
     print_green "Done"
@@ -733,12 +734,12 @@ verify_artifacts() {
     *)
     ;;
   esac
-  echo "Checking $_name firmware checksum..."
+  echo -n "Checking $_name firmware checksum..."
   sha256sum --check <(echo $(cat $_hash_file | cut -d ' ' -f 1) $_update_file) >> $ERR_LOG_FILE 2>&1
   error_check "Failed to verify $_name firmware checksum"
   print_green "Done"
   if [ -v PLATFORM_SIGN_KEY ]; then
-    echo "Checking $_name firmware signature..."
+    echo -n "Checking $_name firmware signature..."
     (cat $_hash_file) | gpg --verify $_sign_file -
     error_check "Failed to verify $_name firmware signature."
   fi

--- a/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
+++ b/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
@@ -705,8 +705,10 @@ download_keys() {
 }
 
 get_signing_keys() {
-    wget -q https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/master/$PLATFORM_SIGN_KEY -O - | gpg --import -
+    echo "Getting platform specific GPG key... "
+    wget -q https://raw.githubusercontent.com/3mdeb/3mdeb-secpack/master/$PLATFORM_SIGN_KEY -O - | gpg --import - >> $ERR_LOG_FILE 2>&1
     error_check "Cannot get platform specific key to verify signatures."
+    print_green "Done"
 }
 
 verify_artifacts() {
@@ -732,11 +734,13 @@ verify_artifacts() {
     ;;
   esac
   echo "Checking $_name firmware checksum..."
-  sha256sum --check <(echo $(cat $_hash_file | cut -d ' ' -f 1) $_update_file)
+  sha256sum --check <(echo $(cat $_hash_file | cut -d ' ' -f 1) $_update_file) >> $ERR_LOG_FILE 2>&1
   error_check "Failed to verify $_name firmware checksum"
+  print_green "Done"
   if [ -v PLATFORM_SIGN_KEY ]; then
     echo "Checking $_name firmware signature..."
     (cat $_hash_file) | gpg --verify $_sign_file -
     error_check "Failed to verify $_name firmware signature."
   fi
+  print_green "Done"
 }

--- a/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
+++ b/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
@@ -75,7 +75,7 @@ fum_exit() {
 
 error_exit() {
   _error_msg="$1"
-  if [ -n $_error_msg ]; then
+  if [ -n "$_error_msg" ]; then
     # Avoid printing empty line if no message was passed
     print_error "$_error_msg"
   fi

--- a/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
+++ b/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
@@ -75,7 +75,10 @@ fum_exit() {
 
 error_exit() {
   _error_msg="$1"
-  print_error "$_error_msg"
+  if [ -n $_error_msg ]; then
+    # Avoid printing empty line if no message was passed
+    print_error "$_error_msg"
+  fi
   fum_exit
   exit 1
 }


### PR DESCRIPTION
Make the console output for settings and logo migration a bit more understandable to users, and pipe all cbfstool messages including stderr to error logs