### PR TITLE
workflows: rerun build step in case of error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
             else
               echo "Build command failed on attempt $attempt"
               if [ $attempt -lt 5 ]; then
-                sleep 5  # Wait for some time before retrying
+                sleep 5
               fi
             fi
           done
-        continue-on-error: true  # Continue to the next step even if the shell command fails
+        continue-on-error: true
       - name: Report build command
         run: |
           if [ ${{ steps.build_image.outcome }} == 'failure' ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,28 @@ jobs:
           path: "meta-dts"
       - name: Build DTS image
         shell: bash
+        id: build_image
         run: |
-          kas-container build meta-dts/kas.yml
+          for attempt in {1..5}; do
+            if kas-container build meta-dts/kas.yml; then
+              echo "Build command succeeded on attempt $attempt"
+              break
+            else
+              echo "Build command failed on attempt $attempt"
+              if [ $attempt -lt 5 ]; then
+                sleep 5  # Wait for some time before retrying
+              fi
+            fi
+          done
+        continue-on-error: true  # Continue to the next step even if the shell command fails
+      - name: Report build command
+        run: |
+          if [ ${{ steps.build_image.outcome }} == 'failure' ]; then
+            echo "All build attempts failed."
+            exit 1
+          else
+            echo "At least one build attempt succeeded."
+          fi
   deploy-images:
     name: Deploy DTS artifacts on boot.dasharo.com
     if: always()

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -25,11 +25,11 @@ jobs:
             else
               echo "Build command failed on attempt $attempt"
               if [ $attempt -lt 5 ]; then
-                sleep 5  # Wait for some time before retrying
+                sleep 5
               fi
             fi
           done
-        continue-on-error: true  # Continue to the next step even if the shell command fails
+        continue-on-error: true
       - name: Report build command
         run: |
           if [ ${{ steps.build_image.outcome }} == 'failure' ]; then

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -16,8 +16,28 @@ jobs:
           path: "meta-dts"
       - name: Build DTS image
         shell: bash
+        id: build_image
         run: |
-          kas-container build meta-dts/kas.yml
+          for attempt in {1..5}; do
+            if kas-container build meta-dts/kas.yml; then
+              echo "Build command succeeded on attempt $attempt"
+              break
+            else
+              echo "Build command failed on attempt $attempt"
+              if [ $attempt -lt 5 ]; then
+                sleep 5  # Wait for some time before retrying
+              fi
+            fi
+          done
+        continue-on-error: true  # Continue to the next step even if the shell command fails
+      - name: Report build command
+        run: |
+          if [ ${{ steps.build_image.outcome }} == 'failure' ]; then
+            echo "All build attempts failed."
+            exit 1
+          else
+            echo "At least one build attempt succeeded."
+          fi
   deploy-images:
     name: Deploy DTS artifacts on GitHub Releases tab
     if: always()

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -36,11 +36,11 @@ jobs:
             else
               echo "Build command failed on attempt $attempt"
               if [ $attempt -lt 5 ]; then
-                sleep 5  # Wait for some time before retrying
+                sleep 5
               fi
             fi
           done
-        continue-on-error: true  # Continue to the next step even if the shell command fails
+        continue-on-error: true
       - name: Report build command
         run: |
           if [ ${{ steps.build_image.outcome }} == 'failure' ]; then

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -21,11 +21,34 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: "meta-dts"
-      - name: Build DTS image
+      - name: Prepare cache-less build configuration
         shell: bash
         run: |
           sed -i '/cache.yml/d' meta-dts/kas.yml
-          kas-container build meta-dts/kas.yml
+      - name: Build DTS image
+        shell: bash
+        id: build_image
+        run: |
+          for attempt in {1..5}; do
+            if kas-container build meta-dts/kas.yml; then
+              echo "Build command succeeded on attempt $attempt"
+              break
+            else
+              echo "Build command failed on attempt $attempt"
+              if [ $attempt -lt 5 ]; then
+                sleep 5  # Wait for some time before retrying
+              fi
+            fi
+          done
+        continue-on-error: true  # Continue to the next step even if the shell command fails
+      - name: Report build command
+        run: |
+          if [ ${{ steps.build_image.outcome }} == 'failure' ]; then
+            echo "All build attempts failed."
+            exit 1
+          else
+            echo "At least one build attempt succeeded."
+          fi
   deploy-cache:
     name: Deploy cache on cache.dasharo.com
     if: always()


### PR DESCRIPTION
Sometimes we run into random errors while building DTS image (e.g. unable to fetch repository from github etc.). Thanks to this we will try maximum 5 times to build an image before giving up.