### PR TITLE
Add flags for NovaCustom EC flashing

### DIFF
--- a/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
+++ b/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
@@ -178,7 +178,7 @@ board_config() {
           NEED_BOOTSPLASH_MIGRATION="false"
           NEED_BLOB_TRANSMISSION="false"
           PROGRAMMER_BIOS="internal"
-          PROGRAMMER_EC="ite_ec"
+          PROGRAMMER_EC="ite_ec:boardmismatch=force,romsize=128K,autoload=disable"
           if check_if_dasharo; then
           # if v1.5.1 or older, flash the whole bios region
           # TODO: Let DTS determine which parameters are suitable.
@@ -212,7 +212,7 @@ board_config() {
           NEED_BOOTSPLASH_MIGRATION="false"
           NEED_BLOB_TRANSMISSION="false"
           PROGRAMMER_BIOS="internal"
-          PROGRAMMER_EC="ite_ec"
+          PROGRAMMER_EC="ite_ec:boardmismatch=force,romsize=128K,autoload=disable"
           if check_if_dasharo; then
           # if v1.5.1 or older, flash the whole bios region
           # TODO: Let DTS determine which parameters are suitable.
@@ -245,7 +245,7 @@ board_config() {
           NEED_SMMSTORE_MIGRATION="true"
           NEED_BLOB_TRANSMISSION="false"
           PROGRAMMER_BIOS="internal"
-          PROGRAMMER_EC="ite_ec"
+          PROGRAMMER_EC="ite_ec:boardmismatch=force,romsize=128K,autoload=disable"
           if check_if_dasharo; then
           # if v1.7.2 or older, flash the whole bios region
           # TODO: Let DTS determine which parameters are suitable.
@@ -282,7 +282,7 @@ board_config() {
           NEED_BOOTSPLASH_MIGRATION="false"
           NEED_BLOB_TRANSMISSION="false"
           PROGRAMMER_BIOS="internal"
-          PROGRAMMER_EC="ite_ec"
+          PROGRAMMER_EC="ite_ec:boardmismatch=force,romsize=128K,autoload=disable"
           if check_if_dasharo; then
           # if v1.7.2 or older, flash the whole bios region
           # TODO: Let DTS determine which parameters are suitable.


### PR DESCRIPTION
Fix for issue https://github.com/Dasharo/dasharo-issues/issues/699. Verified *only on* `NV41MZ`.

Before the changes:
```shell
Waiting for network connection ...
Checking if board is Dasharo compatible.
Gathering flash chip and chipset information...
Flash information: vendor="Programmer" name="Opaque flash chip"
Flash size: 16M
Getting platform specific GPG key... Done
Backing up BIOS firmware and store it locally...
Remember that firmware is also backed up in HCL report.
Checking for Open Source Embedded Controller firmware
Backing up EC firmware...
Failed to read EC firmware backup : (1)
```

After the changes:
```shell
Waiting for network connection ...
Checking if board is Dasharo compatible.
Gathering flash chip and chipset information...
Flash information: vendor="Programmer" name="Opaque flash chip"
Flash size: 16M
Getting platform specific GPG key... Done
Backing up BIOS firmware and store it locally...
Remember that firmware is also backed up in HCL report.
Checking for Open Source Embedded Controller firmware
Backing up EC firmware...
(...)
Installing EC...
Successfully installed Dasharo EC firmware
Found file config at 0x6af80, type raw, compressed 5155, size 18486
CONFIG_VBOOT=y
Installing Dasharo firmware...
Successfully installed Dasharo firmware
Syncing disks... Done.
The computer will shut down automatically in 5 seconds
Rebooting in 5s:
5...
4...
(...)
```