### PR TITLE
Change boot partition to efi type

### DIFF
--- a/meta-dts-distro/wic/usb-stick-dts.wks.in
+++ b/meta-dts-distro/wic/usb-stick-dts.wks.in
@@ -1,4 +1,4 @@
 bootloader --timeout=0 --append=" rootwait"
 
-part /boot --source bootimg-biosplusefi --sourceparams="loader=grub-efi" --ondisk sda --label dts-boot --align 1024 --use-uuid --active
+part /boot --source bootimg-biosplusefi --sourceparams="loader=grub-efi" --ondisk sda --label dts-boot --align 1024 --use-uuid --active --system-id 0xef
 part /     --source rootfs --fstype=ext4                                 --ondisk sda --label dts-root --align 1024 --use-uuid --fixed-size 1024


### PR DESCRIPTION
To be able to use both BIOS and UEFI BIOS the boot partition should be a part of MBR partition table and have EFI type. Solution for https://github.com/Dasharo/dasharo-issues/issues/692.

**Logs for verification**:

Before the changes (using `fdisk`):
```bash
Disk /dev/sdc: 14.46 GiB, 15525216256 bytes, 30322688 sectors
Disk model: USB DISK 2.0    
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x32e7839e

Device     Boot Start     End Sectors  Size Id Type
/dev/sdc1  *     2048   78569   76522 37.4M  c W95 FAT32 (LBA)
/dev/sdc2       79872 2177023 2097152    1G 83 Linux
```
After the changes (using `fdisk`):
```bash
Disk /dev/sdc: 14.46 GiB, 15525216256 bytes, 30322688 sectors
Disk model: USB DISK 2.0    
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: dos
Disk identifier: 0x98e3285d

Device     Boot Start     End Sectors  Size Id Type
/dev/sdc1  *     2048   78569   76522 37.4M ef EFI (FAT-12/16/32)
/dev/sdc2       79872 2177023 2097152    1G 83 Linux
```