### PR TITLE
Fix setting EFI_VARS config for build with UEFI SB enabled

### DIFF
--- a/kas-uefi-sb.yml
+++ b/kas-uefi-sb.yml
@@ -11,7 +11,7 @@ target:
 
 repos:
   meta-secure-core:
-    url: https://github.com/jiazhang0/meta-secure-core
+    url: https://github.com/Wind-River/meta-secure-core
     refspec: fa438247c3e61d7f746687d85ef3b0dd66dc6b3f
     layers:
       meta-efi-secure-boot:

--- a/meta-dts-distro/recipes-kernel/kernel/linux-yocto_%.bbappend
+++ b/meta-dts-distro/recipes-kernel/kernel/linux-yocto_%.bbappend
@@ -19,3 +19,6 @@ SRC_URI:append = " \
     file://ntfs-enable.cfg \
     file://exfat-enable.cfg \
 "
+
+KERNEL_FEATURES:remove:x86 = " ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '${efi_secure_boot_sccs}', '', d)}"
+KERNEL_FEATURES:remove:x86-64 = " ${@bb.utils.contains('DISTRO_FEATURES', 'efi-secure-boot', '${efi_secure_boot_sccs}', '', d)}"


### PR DESCRIPTION
This configuration variable is already set to m by meta-secure-core layer and its sublayer.

The issue is documented in https://github.com/Dasharo/dasharo-issues/issues/729.