### PR TITLE
Add system clock synving during boot

### DIFF
--- a/meta-dts-distro/recipes-dts/dts/dts/dts
+++ b/meta-dts-distro/recipes-dts/dts/dts/dts
@@ -103,6 +103,7 @@ while : ; do
           echo "Please consider supporting Dasharo by sending the logs next time."
           ;;
       esac
+      sync_clocks
       if [ "${SEND_LOGS}" == "true" ]; then
           # DEPLOY_REPORT variable is used in dasharo-hcl-report to determine
           # which logs should be printed in the terminal, in the future whole
@@ -132,12 +133,14 @@ while : ; do
         fi
       fi
 
+      sync_clocks
       if [ -n "${logs_sent}" ]; then
           ${CMD_DASHARO_DEPLOY} install
       fi
       ;;
     3)
       if check_if_dasharo; then
+	sync_clocks
         ${CMD_DASHARO_DEPLOY} restore
       fi
       ;;
@@ -194,6 +197,7 @@ while : ; do
             esac
         fi
 
+	sync_clocks
         # Use regular update process for everything else
         ${CMD_DASHARO_DEPLOY} update
       fi

--- a/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
+++ b/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
@@ -1206,3 +1206,11 @@ handle_fw_switching() {
     fi
   fi
 }
+
+sync_clocks() {
+  echo "Waiting for system clock to be synced ..."
+  chronyc waitsync 10 0 0 5 &> /dev/null
+  if [[ $? -ne 0 ]]; then
+    print_warning "Failed to sync system clock with NTP server!"
+  fi
+}


### PR DESCRIPTION
The clocks are being synced by chronyd.service, but it starts with a delay, which may cause some problems with unsynced clocks. So, sync the clocks manually at DTS boot.

Solves issue https://github.com/Dasharo/dasharo-issues/issues/732.