### PR TITLE
dts: dts-functions: make dts not use ICMP for network connection check

### DIFF
--- a/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
+++ b/meta-dts-distro/recipes-dts/dts/dts/dts-functions.sh
@@ -137,7 +137,10 @@ check_network_connection() {
   echo 'Waiting for network connection ...'
   n="10"
   while : ; do
-    ping -c 3 cloud.3mdeb.com > /dev/null 2>&1 && break
+    if wget --spider cloud.3mdeb.com > /dev/null 2>&1; then
+      echo 'Network connection established.'
+      return 0
+    fi
     n=$((n-1))
     if [ "${n}" == "0" ]; then
       echo 'No network connection to 3mdeb cloud, please recheck Ethernet connection'
@@ -145,7 +148,6 @@ check_network_connection() {
     fi
     sleep 1
   done
-  return 0
 }
 
 ## Supported boards configuration


### PR DESCRIPTION
A fix for https://github.com/Dasharo/dasharo-issues/issues/752. The core of the problem revolved around the use of the ping command for network connectivity verification, which relied on ICMP packets. This approach posed limitations in environments where ICMP packets are blocked or filtered, leading to false negatives in connectivity checks. The implementation replaces `ping` with  `wget --spider` that is used to check for cloud.3mdeb.com access without downloading content.  By using `wget`, the script now supports environments where ICMP is not an option