### PR TITLE
Draft: Dts logic test

### DIFF
--- a/unit_tests/dts-logic.robot
+++ b/unit_tests/dts-logic.robot
@@ -1,0 +1,49 @@
+*** Settings ***
+Library             Collections
+Library             OperatingSystem
+Library             Process
+Library             String
+
+
+*** Test Cases ***
+DTS-logic001.001 Dasharo v1.7.2 on NV4x_PZ, heads with heads DES
+    [Documentation]    This test aims to verify that updates on Dasharo v1.7.2
+    ...    on NV4x_PZ eligible for updates to heads with heads DES and
+    ...    regular update are working properly
+    ${COMMAND}=    catenate    SEPARATOR=
+    ...    expect -c '
+    ...    ${SPACE}set env(BOARD_VENDOR) "Notebook";
+    ...    ${SPACE}set env(SYSTEM_MODEL) "NV4xPZ";
+    ...    ${SPACE}set env(BOARD_MODEL) "NV4xPZ";
+    ...    ${SPACE}set env(BIOS_VERSION) "Dasharo (coreboot+UEFI) v1.7.2";
+    ...    ${SPACE}set env(TEST_DES) "y"'
+    ...    ${SPACE}exp/novacustom-Notebook-NV4xPZ-1.7.2-heads-DES.exp
+    ${output}=    Run Process    bash    -c    ${COMMAND}
+    Should Not Contain    ${output.stdout}    expect timeout looking for
+    Should Contain    ${output.stdout}    Successfully switched to Dasharo Heads firmware.
+    Should Contain    ${output.stdout}    Checking Dasharo EC firmware checksum...
+    Should Contain    ${output.stdout}    Checking Dasharo EC firmware signature...
+    Should Contain    ${output.stdout}    Updating EC...
+    Log    ${output.stdout}
+
+# example new tests could look something like this:
+#     ${COMMAND}=    catenate    SEPARATOR=
+#     ...    expect -c '
+#     ...    ${SPACE}set env(BOARD_VENDOR) "other board vendor";
+#     ...    ${SPACE}set env(SYSTEM_MODEL) "other system model";
+#     ...    ${SPACE}set env(BOARD_MODEL) "other board model";
+#     ...    ${SPACE}set env(BIOS_VERSION) "some Dasharo version";
+#     ...    ${SPACE}set env(TEST_DES) "y/n"'
+#     ...    ${SPACE}exp/novacustom-Notebook-NV4xPZ-1.7.2-heads-DES.exp <- we might need more files, but for
+#     very generic updates this one could work
+#     ${output}=    Run Process    bash    -c    ${COMMAND}
+
+#     # this should stay the same always
+#     Should Not Contain    ${output.stdout}    expect timeout looking for
+
+#     # might also have to change the pass conditions though
+#     Should Contain    ${output.stdout}    Successfully switched to Dasharo Heads firmware.
+#     Should Contain    ${output.stdout}    Checking Dasharo EC firmware checksum...
+#     Should Contain    ${output.stdout}    Checking Dasharo EC firmware signature...
+#     Should Contain    ${output.stdout}    Updating EC...
+#     Log    ${output.stdout}

--- a/unit_tests/exp/novacustom-Notebook-NV4xPZ-1.7.2-heads-DES.exp
+++ b/unit_tests/exp/novacustom-Notebook-NV4xPZ-1.7.2-heads-DES.exp
@@ -1,17 +1,10 @@
 #!/usr/bin/expect -f
 
 proc lookfor {pat} {
-    expect timeout { send_user "timeout looking for '$pat'\r\n" ; exit } $pat
+    expect timeout { send_user "expect timeout looking for '$pat'\r\n" ; exit } $pat
 }
 
-# export the right variables, then run the script
-set env(BOARD_VENDOR) "Notebook"
-set env(SYSTEM_MODEL) "NV4xPZ"
-set env(BOARD_MODEL) "NV4xPZ"
-set env(BIOS_VERSION) "Dasharo (coreboot+UEFI) v1.7.2"
-set env(TEST_DES) "y"
-
-# remember the PID so we can kill it when we are done
+# run the script, remember the PID so we can kill it when we are done
 set DTSPID [spawn bash dts-boot]
 
 # enter "Check and apply Dasharo firmware updates" option

--- a/unit_tests/test.exp
+++ b/unit_tests/test.exp
@@ -1,5 +1,9 @@
 #!/usr/bin/expect -f
 
+proc lookfor {pat} {
+    expect timeout { send_user "timeout looking for '$pat'\r\n" ; exit } $pat
+}
+
 # export the right variables, then run the script
 set env(BOARD_VENDOR) "Notebook"
 set env(SYSTEM_MODEL) "NV4xPZ"
@@ -11,30 +15,30 @@ set env(TEST_DES) "y"
 set DTSPID [spawn bash dts-boot]
 
 # enter "Check and apply Dasharo firmware updates" option
-expect "Enter an option: "
+lookfor "Enter an option: "
 send "5\r"
 
 # agree to switch to Dasharo heads firmware
-expect "Would you like to switch to Dasharo heads firmware? (Y|n) "
+lookfor "Would you like to switch to Dasharo heads firmware? (Y|n) "
 send "Y\r"
 
 # update
-expect "Are you sure you want to proceed with update? (Y|n) "
+lookfor "Are you sure you want to proceed with update? (Y|n) "
 send "Y\r"
 
 # verify specification
-expect "Does it match your actual specification? (Y|n) "
+lookfor "Does it match your actual specification? (Y|n) "
 send "Y\r"
 
 # final agreement to update
-expect "Do you want to update Dasharo firmware on your hardware? (Y|n) "
+lookfor "Do you want to update Dasharo firmware on your hardware? (Y|n) "
 send "Y\r"
 
-expect "Press any key to continue"
+lookfor "Press any key to continue"
 send "\r"
 
 # since we are done we can kill the script
-expect "Enter an option: "
+lookfor "Enter an option: "
 exec kill -9 $DTSPID
 
-expect eof
+lookfor eof

--- a/unit_tests/test.exp
+++ b/unit_tests/test.exp
@@ -1,0 +1,40 @@
+#!/usr/bin/expect -f
+
+# export the right variables, then run the script
+set env(BOARD_VENDOR) "Notebook"
+set env(SYSTEM_MODEL) "NV4xPZ"
+set env(BOARD_MODEL) "NV4xPZ"
+set env(BIOS_VERSION) "Dasharo (coreboot+UEFI) v1.7.2"
+set env(TEST_DES) "y"
+
+# remember the PID so we can kill it when we are done
+set DTSPID [spawn bash dts-boot]
+
+# enter "Check and apply Dasharo firmware updates" option
+expect "Enter an option: "
+send "5\r"
+
+# agree to switch to Dasharo heads firmware
+expect "Would you like to switch to Dasharo heads firmware? (Y|n) "
+send "Y\r"
+
+# update
+expect "Are you sure you want to proceed with update? (Y|n) "
+send "Y\r"
+
+# verify specification
+expect "Does it match your actual specification? (Y|n) "
+send "Y\r"
+
+# final agreement to update
+expect "Do you want to update Dasharo firmware on your hardware? (Y|n) "
+send "Y\r"
+
+expect "Press any key to continue"
+send "\r"
+
+# since we are done we can kill the script
+expect "Enter an option: "
+exec kill -9 $DTSPID
+
+expect eof


### PR DESCRIPTION
This is only a proof of concept so far.
You need to download these dependencies to run the test:
```bash
sudo dnf install expect send
```
then if you look at the `test.exp` file, it contains the logic for doing a firmware update on a NV4xPZ Notebook with Dasharo (coreboot+UEFI) v1.7.2.

The idea is that we can run the test with this command:
```bash
expect test.exp
```
and you can see the output then. The idea is that we can then parse that output for crucial lines, that indicate that the update was successful, for example some of these:
```
Successfully switched to Dasharo Heads firmware.
Checking Dasharo EC firmware checksum... Verified.
Checking Dasharo EC firmware signature... Verified.
```

this should be automated, maybe with `bats-core` (?)

and of course, more tests for logic can be added, with more descriptive file names. Then we can test every single "logical path" that the user can take (each one of these tests will have to be a separate `.exp` file with the exports and paths defined to fit the respective scenario).

Then bats-core can be implemented, so that once someone makes a change to the scripts, for example in `meta-dts-distro/recipes-dts/dts/dts/dts` they can quickly run all of the `.exp` tests to make sure that their changes didnt break the desired logic.

(edit: i also added in [this commit](https://github.com/Dasharo/meta-dts/pull/114/commits/b85d2d74c4f4d63b615c615f26e4c47beda3a414) a change, that makes the `expect` script fail if it doesnt encounter the specific string its expecting)