### PR TITLE
reports: dasharo-hcl-report: remove board_config call

### DIFF
--- a/meta-dts-distro/recipes-dts/reports/dasharo-hcl-report/dasharo-hcl-report
+++ b/meta-dts-distro/recipes-dts/reports/dasharo-hcl-report/dasharo-hcl-report
@@ -57,7 +57,6 @@ fi
 
 FULL_UPLOAD_URL="https://cloud.3mdeb.com/index.php/s/"${CLOUDSEND_LOGS_URL}
 
-board_config
 check_flash_chip
 
 mkdir logs


### PR DESCRIPTION
Running HCL on platforms that are not listed in board_config ends on exiting the script. Calling that function was added while working on APU support, as there is multiple flash chip detected when try to use flashrom on that platform so chip name definition was added to specific platform in board_config.

here is no need for that as check_flash_chip function check one by one known chips from the list defined as FLASH_CHIP_LIST (in dts_environment) and uses one, that does not return error when flashrom is invoked.

Later in HCL we uses check_intel_regions func which needs PROGRAMMER_BIOS variable but this is by default defined in dts_enviroment as internal so in HCL we can assume to use this programmer for every platform.