### PR TITLE
workflows: get DTS_VER from tag not dts-distro.conf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,26 @@ jobs:
         id: dts-ver
         shell: bash
         run: |
-          DTS_VER=v`cat meta-dts/meta-dts-distro/conf/distro/dts-distro.conf | grep DISTRO_VERSION | tr -d "\" [A-Z]_="`
-          echo "DTS_VER=${DTS_VER}" >> $GITHUB_OUTPUT
+          # Extract tag version from GITHUB_REF
+          TAG=${GITHUB_REF#refs/tags/}
+          DTS_VER=$(echo "${TAG}" | sed -E 's/^v//')
+          echo "DTS_VER=${DTS_VER}" >> $GITHUB_ENV
+      - name: Validate DTS_VER
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          # Retrieve DTS_VER from previous step
+          DTS_VER_EXPECTED="${{ env.DTS_VER }}"
+          DTS_VER_ACTUAL=$(cat meta-dts/meta-dts-distro/conf/distro/dts-distro.conf | grep DISTRO_VERSION | tr -d "\" [A-Z]_=")
+
+          if [ "${DTS_VER_EXPECTED}" != "${DTS_VER_ACTUAL}" ]; then
+            echo "Tag (${DTS_VER_EXPECTED}) does not match version (${DTS_VER_ACTUAL}) in `meta-dts/meta-dts-distro/conf/distro/dts-distro.conf`"
+            exit 1
+          fi
       - name: Deploy DTS on boot.dasharo.com
         shell: bash
         run: |
-          DTS_VER="${{steps.dts-ver.outputs.DTS_VER}}"
+          DTS_VER="${{ env.DTS_VER }}"
           ssh -i ~/.ssh/dts-ci-key builder@10.1.40.2 "mkdir -p boot/dts/${DTS_VER}"
           cd build/tmp/deploy/images/genericx86-64/
           cp bzImage bzImage-${DTS_VER}
@@ -91,7 +105,7 @@ jobs:
       - name: Deploy sha256 on boot.dasharo.com
         shell: bash
         run: |
-          DTS_VER="${{steps.dts-ver.outputs.DTS_VER}}"
+          DTS_VER="${{ env.DTS_VER }}"
           cd build/tmp/deploy/images/genericx86-64/
           sha256sum bzImage-${DTS_VER} > bzImage-${DTS_VER}.sha256
           sha256sum dts-base-image-${DTS_VER}.cpio.gz > dts-base-image-${DTS_VER}.cpio.gz.sha256
@@ -110,12 +124,12 @@ jobs:
       - name: Update iPXE menu
         shell: bash
         run: |
-          ./meta-dts/scripts/generate-ipxe-menu.sh ${{steps.dts-ver.outputs.DTS_VER}}
+          ./meta-dts/scripts/generate-ipxe-menu.sh ${{ env.DTS_VER }}
           scp -i ~/.ssh/dts-ci-key dts.ipxe builder@10.1.40.2:boot/dts/
       - name: Trigger signing
         shell: bash
         run: |
-          DTS_VER="${{steps.dts-ver.outputs.DTS_VER}}"
+          DTS_VER="${{ env.DTS_VER }}"
           git clone ssh://git@git.3mdeb.com:2222/3mdeb/dts-release-cicd-pipeline.git
           cd dts-release-cicd-pipeline
           echo ${DTS_VER} > LATEST_RELEASE

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -65,12 +65,26 @@ jobs:
         id: dts-ver
         shell: bash
         run: |
-          DTS_VER=v`cat meta-dts/meta-dts-distro/conf/distro/dts-distro.conf | grep DISTRO_VERSION | tr -d "\" [A-Z]_="`
-          echo "DTS_VER=${DTS_VER}" >> $GITHUB_OUTPUT
+          # Extract tag version from GITHUB_REF
+          TAG=${GITHUB_REF#refs/tags/}
+          DTS_VER=$(echo "${TAG}" | sed -E 's/^v//')
+          echo "DTS_VER=${DTS_VER}" >> $GITHUB_ENV
+      - name: Validate DTS_VER
+        if: ${{ success() }}
+        shell: bash
+        run: |
+          # Retrieve DTS_VER from previous step
+          DTS_VER_EXPECTED="${{ env.DTS_VER }}"
+          DTS_VER_ACTUAL=$(cat meta-dts/meta-dts-distro/conf/distro/dts-distro.conf | grep DISTRO_VERSION | tr -d "\" [A-Z]_=")
+
+          if [ "${DTS_VER_EXPECTED}" != "${DTS_VER_ACTUAL}" ]; then
+            echo "Tag (${DTS_VER_EXPECTED}) does not match version (${DTS_VER_ACTUAL}) in `meta-dts/meta-dts-distro/conf/distro/dts-distro.conf`"
+            exit 1
+          fi
       - name: Deploy DTS on boot.dasharo.com
         shell: bash
         run: |
-          DTS_VER="${{steps.dts-ver.outputs.DTS_VER}}"
+          DTS_VER="${{ env.DTS_VER }}"
           ssh -i ~/.ssh/dts-ci-key builder@10.1.40.2 "mkdir -p boot/dts/${DTS_VER}"
           cd build/tmp/deploy/images/genericx86-64/
           cp bzImage bzImage-${DTS_VER}
@@ -86,7 +100,7 @@ jobs:
       - name: Deploy sha256 on boot.dasharo.com
         shell: bash
         run: |
-          DTS_VER="${{steps.dts-ver.outputs.DTS_VER}}"
+          DTS_VER="${{ env.DTS_VER }}"
           cd build/tmp/deploy/images/genericx86-64/
           sha256sum bzImage-${DTS_VER} > bzImage-${DTS_VER}.sha256
           sha256sum dts-base-image-${DTS_VER}.cpio.gz > dts-base-image-${DTS_VER}.cpio.gz.sha256
@@ -101,12 +115,12 @@ jobs:
       - name: Update iPXE menu
         shell: bash
         run: |
-          ./meta-dts/scripts/generate-ipxe-menu.sh ${{steps.dts-ver.outputs.DTS_VER}}
+          ./meta-dts/scripts/generate-ipxe-menu.sh DTS_VER="${{ env.DTS_VER }}"
           scp -i ~/.ssh/dts-ci-key dts-rc.ipxe builder@10.1.40.2:boot/dts/
       - name: Trigger signing
         shell: bash
         run: |
-          DTS_VER="${{steps.dts-ver.outputs.DTS_VER}}"
+          DTS_VER="${{ env.DTS_VER }}"
           git clone ssh://git@git.3mdeb.com:2222/3mdeb/dts-release-cicd-pipeline.git
           cd dts-release-cicd-pipeline
           echo ${DTS_VER} > LATEST_RELEASE


### PR DESCRIPTION
Test will fail if conflicting versions are present in the push tag and `meta-dts/meta-dts-distro/conf/distro/dts-distro.conf`.

Needs testing before merging