### PR TITLE
meta-dts-distro/recipes-support/dasharo-ectool: bump rev for Dasharo ACPI ID

### DIFF
--- a/meta-dts-distro/recipes-support/dasharo-ectool/dasharo-ectool_0.3.8.bb
+++ b/meta-dts-distro/recipes-support/dasharo-ectool/dasharo-ectool_0.3.8.bb
@@ -1,7 +1,7 @@
 inherit cargo
 inherit pkgconfig
 
-SUMMARY = "System76 Open Source Embedded Controller"
+SUMMARY = "Dasharo Open Source Embedded Controller utility"
 HOMEPAGE = "https://github.com/Dasharo/ec"
 
 LICENSE = "MIT"
@@ -40,7 +40,7 @@ SRC_URI:append = " \
     crate://crates.io/winapi/0.3.9 \
 "
 
-SRCREV = "2b2c17ac6e61f45e0fc1bcf6b907a8289f37bcc4"
+SRCREV = "4ae73b9d2cc2ec34c760c7774a7859d240c4c8dd"
 
 SRC_URI[atty-0.2.14.sha256sum] = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 SRC_URI[autocfg-1.1.0.sha256sum] = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"


### PR DESCRIPTION
Needed for dasharo_ectool functionality on MTL v0.9.0-rc10 and newer.