### PR TITLE
recipes-bsp/coreboot-utils/intelp2m_git.bb: fix buildpath error

### DIFF
--- a/meta-dts-distro/recipes-bsp/coreboot-utils/intelp2m_git.bb
+++ b/meta-dts-distro/recipes-bsp/coreboot-utils/intelp2m_git.bb
@@ -22,11 +22,9 @@ inherit go
 
 do_compile() {
     export GOARCH="${TARGET_GOARCH}"
-    export GOPATH="${WORKDIR}/git/"
-
     cd ${S}
-
-    oe_runmake
+    go version
+    go build -trimpath -v -o intelp2m
 }
 
 do_install() {


### PR DESCRIPTION
golang is adding path if GO_PATH is created and removing this and adding -trimpath to build process should remove path inside binary