### PR TITLE
recipes-bsp: coreboot-utils: nvramtool - Fix buildpath warning

### DIFF
--- a/meta-dts-distro/recipes-bsp/coreboot-utils/nvramtool_git.bb
+++ b/meta-dts-distro/recipes-bsp/coreboot-utils/nvramtool_git.bb
@@ -7,6 +7,8 @@ EXTRA_OEMAKE = ' \
                 PREFIX="${prefix}" \
                 '
 
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
 do_compile () {
   oe_runmake -C util/nvramtool
 }


### PR DESCRIPTION
This patch add to recipe INHIBIT_PACKAGE_DEBUG_SPLIT="1" this change force system not to build debug packages and do strip of executables to remove TMPDIR from binary file.