### PR TITLE
recipes-bsp: txe-secure-boot: smmstoretool fix buildpaths warning

### DIFF
--- a/meta-dts-distro/recipes-bsp/txe-secure-boot/smmstoretool_git.bb
+++ b/meta-dts-distro/recipes-bsp/txe-secure-boot/smmstoretool_git.bb
@@ -17,6 +17,8 @@ inherit pkgconfig
 
 S = "${WORKDIR}/git/util/smmstoretool"
 
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+
 EXTRA_OEMAKE = ' \
                 DESTDIR="${D}" \
                 PREFIX="${prefix}" \


### PR DESCRIPTION
This patch add to recipe INHIBIT_PACKAGE_DEBUG_SPLIT = "1" this change force system not to build debug packages and do strip of executables to remove TMPDIR from binary file.