### PR TITLE
conf/distro/dts-distro.conf: ROOT_HOME was missing

### DIFF
--- a/meta-dts-distro/conf/distro/dts-distro.conf
+++ b/meta-dts-distro/conf/distro/dts-distro.conf
@@ -23,6 +23,7 @@ VIRTUAL-RUNTIME_syslog = ""
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "sysvinit pulseaudio"
 VIRTUAL-RUNTIME_vim = "vim"
 
+ROOT_HOME = '/root'
 ROOT_PASSWORD = "jlz9IbDJscvTcTjpDkk1xVoPZnxIm1K5"
 
 WKS_FILES = "usb-stick-dts.wks.in"


### PR DESCRIPTION
WARNING: systemd-1_255.4-r0 do_install: Using /home/root as root
	user's home directory is not fully supported by systemd

Set ROOT_HOME to "/root" to avoid such warning.