### PR TITLE
recipes-gnome: gcab: add bbapend that disable qa tests

### DIFF
--- a/meta-dts-distro/recipes-gnome/gcab/gcab_%.bbappend
+++ b/meta-dts-distro/recipes-gnome/gcab/gcab_%.bbappend
@@ -1,0 +1,1 @@
+do_package_qa[noexec] = "1"


### PR DESCRIPTION
WARNING: gcab-1.6-r0 do_package_qa: QA Issue: File /usr/src/debug/gcab/1.6/libgcab/gcab-enums.c in package gcab-src contains reference to TMPDIR [buildpaths]

Disable QA checkout for this package:
do_package_qa[noexec] = "1"