### PR TITLE
recipes-connectivity: wolfssl: Ignore [buildpaths] QA ISSUE

### DIFF
--- a/meta-dts-distro/recipes-connectivity/wolfssl/wolfssl_%.bbappend
+++ b/meta-dts-distro/recipes-connectivity/wolfssl/wolfssl_%.bbappend
@@ -1,0 +1,1 @@
+INSANE_SKIP:${PN} += "buildpaths"


### PR DESCRIPTION
This patch fixes:
WARNING: wolfssl-5.7.0-r0 do_package_qa: QA Issue:
	File /usr/lib/libwolfssl.so.42.1.0 in package wolfssl
	contains reference to TMPDIR [buildpaths]