### PR TITLE
python3-roca-detect: fix missing dependencies

### DIFF
--- a/meta-dts-distro/recipes-devtool/python/python3-pgpdump_1.5.bb
+++ b/meta-dts-distro/recipes-devtool/python/python3-pgpdump_1.5.bb
@@ -1,0 +1,8 @@
+SUMMARY = "PGP packet parser library"
+HOMEPAGE = "https://pypi.org/project/pgpdump/"
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://COPYRIGHT;md5=d8b3cb8278a76dc8de839fecf2e15e64"
+
+SRC_URI[sha256sum] = "1c4700857bf7ba735b08cfe4101aa3a4f5fd839657af249c17b2697c20829668"
+
+inherit pypi setuptools3

--- a/meta-dts-distro/recipes-devtool/python/python3-roca-detect_git.bb
+++ b/meta-dts-distro/recipes-devtool/python/python3-roca-detect_git.bb
@@ -1,46 +1,23 @@
-# Recipe created by recipetool
-# This is the basis of a recipe and may need further editing in order to be fully functional.
-# (Feel free to remove these comments when editing.)
-
 SUMMARY = "ROCA key detector / fingerprinter tool"
 HOMEPAGE = "https://github.com/crocs-muni/roca"
-# NOTE: License in setup.py/PKGINFO is: MIT
-# WARNING: the following LICENSE and LIC_FILES_CHKSUM values are best guesses - it is
-# your responsibility to verify that the values are complete and correct.
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=2a6b12210371b9201fd100ff0cbef45a"
 
 PV = "v1.2.12+git"
 
 SRC_URI = "git://github.com/crocs-muni/roca;protocol=https;branch=master"
-
-# Modify these as desired
 SRCREV = "df6071d502f68701427f8b1d409cab22055ad1b7"
 
 S = "${WORKDIR}/git"
 
 inherit setuptools3
 
-# WARNING: the following rdepends are determined through basic analysis of the
-# python sources, and might not be 100% accurate.
-RDEPENDS:${PN} += "python3-compression python3-core python3-crypt python3-datetime python3-io python3-json python3-logging python3-math python3-netclient python3-unittest python3-future python3-coloredlogs"
-
-# WARNING: We were unable to map the following python package/module
-# dependencies to the bitbake packages which include them:
-#    apk_parse.apk
-#    coloredlogs
-#    cryptography.hazmat.backends
-#    cryptography.hazmat.backends.openssl.backend
-#    cryptography.hazmat.backends.openssl.x509
-#    cryptography.hazmat.primitives
-#    cryptography.hazmat.primitives.asymmetric.rsa
-#    cryptography.hazmat.primitives.serialization
-#    cryptography.x509
-#    cryptography.x509.base
-#    cryptography.x509.oid
-#    future.utils
-#    jks
-#    past.builtins
-#    pgpdump.data
-#    pgpdump.packet
-#    pkg_resources
+RDEPENDS:${PN} += " \
+                    python3 \
+                    python3-cryptography \
+                    python3-six \
+                    python3-future \
+                    python3-coloredlogs \
+                    python3-pgpdump \
+                    python3-dateutil \
+                    "


### PR DESCRIPTION
Do we need this tool? Is it even maintained? Has it ever worked (if not then clearly we don't need it as someone would have noticed it's broken)
From what I can see last commit was 4 years ago, last comment by maintainer (PR/issue) probably closer to 6. 

roca-detect requires `python3-cryptography`:

```
bash-5.2# ssh-keygen
(...)
bash-5.2# roca-detect .ssh/
Traceback (most recent call last):
  File "/usr/bin/roca-detect", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/lib/python3.12/site-packages/roca/detect.py", line 2253, in main
    app.main()
  File "/usr/lib/python3.12/site-packages/roca/detect.py", line 2248, in main
    self.work()
  File "/usr/lib/python3.12/site-packages/roca/detect.py", line 2143, in work
    ret = self.process_inputs()
          ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/roca/detect.py", line 1054, in process_inputs
    sub = self.process_dir(fname)
          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/roca/detect.py", line 1099, in process_dir
    sub = self.process_file(fh.read(), fname)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/roca/detect.py", line 1127, in process_file
    ret.append(self.process_der(data, name))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/roca/detect.py", line 1368, in process_der
    from cryptography.x509.base import load_der_x509_certificate
ModuleNotFoundError: No module named 'cryptography'
```

After adding it there is still missing `pgpdump`:

```
bash-5.2# roca-detect /home/root/.ssh
2024-09-28 15:58:09 [588] WARNING Could not import pgpdump, try running: pip install pgpdump
2024-09-28 15:58:09 [588] INFO ### SUMMARY ####################
2024-09-28 15:58:09 [588] INFO Records tested: 0
2024-09-28 15:58:09 [588] INFO .. PEM certs: . . . 0
2024-09-28 15:58:09 [588] INFO .. DER certs: . . . 0
2024-09-28 15:58:09 [588] INFO .. RSA key files: . 0
2024-09-28 15:58:09 [588] INFO .. PGP master keys: 0
2024-09-28 15:58:09 [588] INFO .. PGP total keys:  0
2024-09-28 15:58:09 [588] INFO .. SSH keys:  . . . 0
2024-09-28 15:58:09 [588] INFO .. APK keys:  . . . 0
2024-09-28 15:58:09 [588] INFO .. JSON keys: . . . 0
2024-09-28 15:58:09 [588] INFO .. LDIFF certs: . . 0
2024-09-28 15:58:09 [588] INFO .. JKS certs: . . . 0
2024-09-28 15:58:09 [588] INFO .. PKCS7: . . . . . 0
2024-09-28 15:58:09 [588] INFO No fingerprinted keys found (OK)
2024-09-28 15:58:09 [588] INFO ################################
bash-5.2# ls -lh /home/root/.ssh/
total 8.0K
-rw------- 1 root root 419 Sep 28 15:56 id_ed25519
-rw-r--r-- 1 root root 104 Sep 28 15:56 id_ed25519.pub
```

There is still question if this tool even works? Current state:

```shell
bash-5.2# roca-detect .ssh
2024-09-28 17:13:07 [588] ERROR Exception in processing PGP rec file id_ed25519.pub: incorrect binary data
(...)
bash-5.2# roca-detect /home/root/.dasharo-gnupg/
2024-09-28 17:13:58 [590] ERROR Exception in processing PGP file trustdb.gpg: 'utf-8' codec can't decode byte 0x98 in position 14: invalid start byte
(...)
```

Ok, problem was with generated key type, with `ssh-keygen -t rsa` ed key still fails but not rsa:

```
2024-09-28 17:20:39 [688] ERROR Exception in processing PGP rec file id_ed25519.pub: incorrect binary data
2024-09-28 17:20:39 [688] INFO ### SUMMARY ####################
2024-09-28 17:20:39 [688] INFO Records tested: 1
2024-09-28 17:20:39 [688] INFO .. PEM certs: . . . 0
2024-09-28 17:20:39 [688] INFO .. DER certs: . . . 0
2024-09-28 17:20:39 [688] INFO .. RSA key files: . 0
2024-09-28 17:20:39 [688] INFO .. PGP master keys: 0
2024-09-28 17:20:39 [688] INFO .. PGP total keys:  0
2024-09-28 17:20:39 [688] INFO .. SSH keys:  . . . 1
2024-09-28 17:20:39 [688] INFO .. APK keys:  . . . 0
2024-09-28 17:20:39 [688] INFO .. JSON keys: . . . 0
2024-09-28 17:20:39 [688] INFO .. LDIFF certs: . . 0
2024-09-28 17:20:39 [688] INFO .. JKS certs: . . . 0
2024-09-28 17:20:39 [688] INFO .. PKCS7: . . . . . 0
2024-09-28 17:20:39 [688] INFO No fingerprinted keys found (OK)
2024-09-28 17:20:39 [688] INFO ################################
```