### PR TITLE
DTS fix UEFI SB build

### DIFF
--- a/kas-uefi-sb.yml
+++ b/kas-uefi-sb.yml
@@ -13,18 +13,13 @@ target:
 repos:
   meta-secure-core:
     url: https://github.com/Wind-River/meta-secure-core
-    refspec: fa438247c3e61d7f746687d85ef3b0dd66dc6b3f
+    refspec: 0aa7452355abc39b700f8787eab1b655f6099407
     layers:
       meta-efi-secure-boot:
-      meta:
+      meta-secure-core-common:
       meta-signing-key:
       meta-tpm2:
 
   meta-openembedded:
-    url: https://git.openembedded.org/meta-openembedded
-    refspec: 0b78362654262145415df8211052442823b9ec9b
     layers:
-      meta-oe:
-      meta-networking:
-      meta-python:
       meta-perl:

--- a/meta-dts-distro/conf/distro/dts-sb-distro.conf
+++ b/meta-dts-distro/conf/distro/dts-sb-distro.conf
@@ -39,3 +39,5 @@ MACHINE_FEATURES:append = " efi"
 
 DEBUG_FLAGS:forcevariable = ""
 IMAGE_INSTALL:append = " kernel-image-bzimage"
+
+PREFERRED_VERSION_tpm2-tss-engine = "1.1.0"


### PR DESCRIPTION
Before changes:

```
`ERROR: Layer networking-layer is not compatible with the core layer which only supports these series: scarthgap (layer is compatible with kirkstone)`
```

Using the same refspec as `common.yml`:

```diff
   meta-openembedded:
-    url: https://git.openembedded.org/meta-openembedded
-    refspec: 0b78362654262145415df8211052442823b9ec9b
     layers:
-      meta-oe:
-      meta-networking:
-      meta-python:
       meta-perl:
```

Results in:

```
ERROR: Layer secure-core is not compatible with the core layer which only supports these series: scarthgap (layer is compatible with kirkstone honister langdale)
```

After updating `meta-secure-core`

```diff
   meta-secure-core:
     url: https://github.com/Wind-River/meta-secure-core
-    refspec: fa438247c3e61d7f746687d85ef3b0dd66dc6b3f
+    refspec: 0aa7452355abc39b700f8787eab1b655f6099407
     layers:
       meta-efi-secure-boot:
-      meta:
+      meta-secure-core-common:
       meta-signing-key:
       meta-tpm2:
```

```
ERROR: Multiple versions of tpm2-tss-engine are due to be built (/work/meta-security/meta-tpm/recipes-tpm2/tpm2-tss-engine/tpm2-tss-engine_1.1.0.bb /work/meta-secure-core/meta-tpm2/recipes-tpm/tpm2-tss-engine/tpm2-tss-engine_1.2.0.bb). Only one version of a given PN should be built in any given build. You likely need to set PREFERRED_VERSION_tpm2-tss-engine to select the correct version or don't depend on multiple versions.
```

After adding preferred version:

```diff
--- a/meta-dts-distro/conf/distro/dts-sb-distro.conf
+++ b/meta-dts-distro/conf/distro/dts-sb-distro.conf
@@ -39,3 +39,5 @@ MACHINE_FEATURES:append = " efi"

 DEBUG_FLAGS:forcevariable = ""
 IMAGE_INSTALL:append = " kernel-image-bzimage"
+
+PREFERRED_VERSION_tpm2-tss-engine = "1.2.0"
```

```
WARNING: preferred version 1.2.0 of tpm2-tss-engine not available (for item tpm2-tss-engine-engines)
WARNING: versions of tpm2-tss-engine available: 1.1.0
```

And ends with the same error as earlier.
With version `1.1.0` used:

```
NOTE: Tasks Summary: Attempted 9031 tasks of which 12 didn't need to be rerun and all succeeded.

Summary: There were 109 WARNING messages.
```

That's a lot of warnings