### PR TITLE
recipes-extended: sbctl: add RDEPENDS to recipe

### DIFF
--- a/meta-dts-distro/recipes-extended/sbctl/sbctl_0.15.4.bb
+++ b/meta-dts-distro/recipes-extended/sbctl/sbctl_0.15.4.bb
@@ -8,6 +8,8 @@ SRC_URI[sha256sum] = "5bc440637b25a78685f426441d195d92939b3ed82278220698159c68bc
 
 S = "${WORKDIR}/${BPN}"
 
+RDEPENDS:${PN} = "binutils util-linux-lsblk"
+
 do_install () {
     install -d ${D}${bindir}
     install -m 0755 ${S}/sbctl ${D}${bindir}/


### PR DESCRIPTION
Dependencies taken from GitHub repository README: needed dependencies are `objcopy` from binutils and `lsblk` from `util-linux`