### PR TITLE
kas: cache.yml: don't use local hash equivalence server

### DIFF
--- a/kas/cache.yml
+++ b/kas/cache.yml
@@ -9,3 +9,5 @@ local_conf_header:
     INHERIT += "own-mirrors"
     LOCAL_PREMIRROR_SERVER ?= "cache.dasharo.com"
     PROJECT_NAME ?= "yocto/dts"
+    BB_SIGNATURE_HANDLER = "OEBasicHash"
+    BB_HASHSERVE = ""


### PR DESCRIPTION
PR removes warning:

```
WARNING: You are using a local hash equivalence server but have configured an sstate mirror.
This will likely mean no sstate will match from the mirror. You may wish to disable the hash equivalence
use (BB_HASHSERVE), or use a hash equivalence server alongside the sstate mirror.
```

Built from scratch:

```
Sstate summary: Wanted 4441 Local 0 Mirrors 4434 Missed 7 Current 0 (99% match, 0% complete)
NOTE: Executing Tasks
(...)
NOTE: Tasks Summary: Attempted 8865 tasks of which 8839 didn't need to be rerun and all succeeded.
```

Built on different machine with local cache

```
Sstate summary: Wanted 1123 Local 9 Mirrors 1107 Missed 7 Current 3318 (99% match, 99% complete)
NOTE: Executing Tasks
NOTE: Tasks Summary: Attempted 8865 tasks of which 8843 didn't need to be rerun and all succeeded.
```