### PR TITLE
workflow: test.yml: use line buffering with grep

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,15 +129,15 @@ jobs:
           echo "::add-mask::$DPP_PASSWORD"
 
           RTE_IP="127.0.0.1" CONFIG="qemu" ./scripts/run.sh dts/dts-e2e.robot -- \
-          -L TRACE \
-          -v snipeit:no \
-          -v dpp_password:$DPP_PASSWORD \
-          -v dpp_download_key:${{matrix.dpp_download_key}} \
-          -v dpp_logs_key:"${{matrix.dpp_logs_key}}" \
-          -v boot_dts_from_ipxe_shell:True \
-          -v dts_ipxe_link:http://${ip_addr}:4321/dts.ipxe \
-          -i ${{ matrix.test }} 2>&1 \
-          | tee ${{ env.LOG_DIR }}/${{ matrix.log_file }} | grep "| PASS |\|| FAIL |"
+            -L TRACE \
+            -v snipeit:no \
+            -v dpp_password:$DPP_PASSWORD \
+            -v dpp_download_key:${{matrix.dpp_download_key}} \
+            -v dpp_logs_key:"${{matrix.dpp_logs_key}}" \
+            -v boot_dts_from_ipxe_shell:True \
+            -v dts_ipxe_link:http://${ip_addr}:4321/dts.ipxe \
+            -i ${{ matrix.test }} 2>&1 \
+            | tee ${{ env.LOG_DIR }}/${{ matrix.log_file }} | grep --line-buffered "| PASS |\|| FAIL |"
 
       - name: Copy log
         shell: bash


### PR DESCRIPTION
Without it grep buffers a lot of lines before output is logged to console and shown in GitHub Actions, usually after every test finishes.