### PR TITLE
Fix DTS Extensions messages

### DIFF
--- a/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
+++ b/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=c846ebb396f8b174b10ded477
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = "git://github.com/Dasharo/dts-scripts;protocol=https;branch=main"
-SRCREV = "d34700cc3c2944a0a969b26d5ed2921ede371f1d"
+SRCREV = "0af94a3818051729c6f7950405b5039f9aa61329"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
DPP Packages are now called DTS Extensions to prevent confusion.

Related PR: https://github.com/Dasharo/dts-scripts/pull/62