### PR TITLE
dts-scripts: fix ODROID-H4 firmware link and initial deployment

### DIFF
--- a/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
+++ b/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=c846ebb396f8b174b10ded477
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = "git://github.com/Dasharo/dts-scripts;protocol=https;branch=main"
-SRCREV = "306dd78dbfbb74068da1d0ed35ae9025b78ba9de"
+SRCREV = "3f59938c9a9de549fe6830a75925534f68373314"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Don't merge before: https://github.com/Dasharo/dts-scripts/pull/73