### PR TITLE
Use Python 3.13 for DTS testing workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           cd open-source-firmware-validation
           if [ ! -d "venv" ]; then
-            python3 -m venv venv
+            python3.13 -m venv venv
           fi
           source venv/bin/activate
           pip install -r requirements.txt


### PR DESCRIPTION
The change was caused by https://github.com/Dasharo/open-source-firmware-validation/pull/952