### PR TITLE
workflow: show '[ WARN ]' lines when running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
             -v boot_dts_from_ipxe_shell:True \
             -v dts_config_ref:"${DTS_CONFIG_REF}" \
             -v dts_ipxe_link:http://${ip_addr}:4321/dts.ipxe 2>&1 \
-            | tee ${{ env.LOG_DIR }}/dts-tests.log | grep --line-buffered "| PASS |\|| FAIL |"
+            | tee ${{ env.LOG_DIR }}/dts-tests.log | grep --line-buffered "| PASS |\|| FAIL |\|\[ WARN \]"
 
       - name: Copy log
         shell: bash


### PR DESCRIPTION
Used e.g. to verify which tests use profile:

```text
[ WARN ] Workflow isn't configured for profile verification.
E2E037: msi-pro-z690-a-ddr5 UEFI Update - DCR                         | PASS |
```