### PR TITLE
Release v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.7.1 - 2025-09-25
+
+### Changed
+
+- Print error and stop update if reading flash during `checking flash layout`
+  fails.
+- Prompt the user to continue the update if BIOS configuration migration fails.
+  Continuing with update will result in all configuration being reset to
+  default.
+- Improve message when sending logs to 3mdeb and print path to archive with
+  logs. In case of failure display link to documentation on how to share logs
+  manually.
+- [DTS: Add recovery information/steps when flashing
+  fails](https://github.com/Dasharo/dasharo-issues/issues/1626) - Rework error
+  message displayed when flashing fails, providing guidance on what the user
+  should do and including 3mdeb contact information.
+
+### Fixed
+
+- [DTS can't send logs in case of wrong
+  credentials](https://github.com/Dasharo/dasharo-issues/issues/1385) - Fixed
+  issue where logs weren't sent if user entered wrong DPP credentials
+  previously.
+- Fixed issue where command error output was being visible when trying to send
+  logs if network interface was down
+- [Automatic FUM update starts on every
+  TTY](https://github.com/Dasharo/dasharo-issues/issues/1603) - Fixed issue
+  where multiple FUM updates were being run simultaneously which resulted in
+  random failures. This resulted in update failing in random place:
+  [Failed to update fw on NovaCUstom V54 iGPU laptop via FUM/DTS (0.9.0 ->
+  1.0.0)](https://github.com/Dasharo/dasharo-issues/issues/1613)
 
 ## 2.7.0 - 2025-09-18
 

--- a/meta-dts-distro/conf/distro/dts-distro.conf
+++ b/meta-dts-distro/conf/distro/dts-distro.conf
@@ -4,7 +4,7 @@ DISTRO = "dts-distro"
 
 # distro name
 DISTRO_NAME = "Dasharo Tools Suite"
-DISTRO_VERSION = "2.7.0"
+DISTRO_VERSION = "2.7.1"
 SDK_VENDOR = "-dtssdk"
 
 MAINTAINER = "3mdeb Sp. z o. o. <contact@3mdeb.com>"

--- a/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
+++ b/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=c846ebb396f8b174b10ded477
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = "git://github.com/Dasharo/dts-scripts;protocol=https;branch=main"
-SRCREV = "b43ab58df36dbe6fa55f044b45860c9565a2c1ea"
+SRCREV = "ad42bda608e1e1db4281b1d263f265f44300ee4e"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
1st run: couple failures, forgot to merge https://github.com/Dasharo/open-source-firmware-validation/pull/1115.
There is also issue with ODROID ultra, someone copied DTS E2E variables from H4+: https://github.com/Dasharo/open-source-firmware-validation/blob/a1694c87c74fda23fb01de0e97e735ced5e83b6a/platform-configs/odroid-h4-ultra.robot#L140

---

Failed tests:

```
E2E007.002 Check old credentials are being overwritten by new :: M... | FAIL |
E2E007.003 Check wrong credentials should not allow to log into DP... | FAIL |
E2E007.005 Check empty e-mail should not pass :: Entering empty e-... | FAIL |
E2E007.006 Check empty password should not pass :: Entering empty ... | FAIL |
E2E007.009 Check DPP credentials with access to only extensions ::... | FAIL |
E2E008: novacustom-v540tnd Fuse Platform - DCR                        | FAIL |
E2E016: novacustom-v560tne Fuse Platform - DCR                        | FAIL |
E2E019: novacustom-v560tnd Fuse Platform - DCR                        | FAIL |
E2E031: msi-pro-z790-p-ddr5 UEFI->Heads Transition - DPP              | FAIL |
E2E043: msi-pro-z690-a-wifi-ddr4 UEFI->Heads Transition - DPP         | FAIL |
```

are expected, heads transition either doesn't work or couldn't be verified for MSI, Fuse platform workflow isn't yet supported for dGPU laptops and credential issues are planned to be fixed in `2.8.0`