### PR TITLE
Enable flashrom Alder Lake test

### DIFF
--- a/meta-dts-distro/recipes-tests/dts-tests/dts-tests/cukinia.conf
+++ b/meta-dts-distro/recipes-tests/dts-tests/dts-tests/cukinia.conf
@@ -11,10 +11,7 @@ as "Check whether the dmidecode package can be started" cukinia_cmd dmidecode --
 as "Check whether the iasl package can be started" cukinia_cmd iasl -v
 as "Check if flashrom supports Tiger Lake" cukinia_cmd /bin/sh -c "flashrom --list-supported | grep 'Tiger Lake U Premium'"
 as "Check if flashrom supports ite_ec programmer" cukinia_cmd /bin/sh -c "flashrom --list-supported | grep 'ite_ec'"
-
-# Alder Lake support is not yet implemented properly yet and is not correctly
-# listed in flashrom
-# as "Check if flashrom supports Alder Lake" cukinia_cmd /bin/sh -c "flashrom # --list-supported | grep 'Alder Lake'"
+as "Check if flashrom supports Alder Lake" cukinia_cmd /bin/sh -c "flashrom --list-supported | grep 'Alder Lake'"
 
 as "Check if dasharo-hcl-report script exists" cukinia_test -x $(which dasharo-hcl-report)
 # as "Check if dasharo-hcl-report script can be executed" cukinia_cmd dasharo-hcl-report


### PR DESCRIPTION
```sh
bash-5.2# cukinia
[PASS] Check whether the ectool package can be started
(...)
[PASS] Check if flashrom supports Tiger Lake
[PASS] Check if flashrom supports ite_ec programmer
[PASS] Check if flashrom supports Alder Lake
(...)
result: 0 failure(s)
```

Passing cukinia test should be also added to [dts-e2e.robot](https://github.com/Dasharo/open-source-firmware-validation/blob/develop/dts/dts-e2e.robot)