### PR TITLE
dts-scripts: add mocking to allow fum, smmstore, and flash testing

### DIFF
--- a/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
+++ b/meta-dts-distro/recipes-dts/dts-scripts/dts-scripts_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSES/Apache-2.0.txt;md5=c846ebb396f8b174b10ded477
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = "git://github.com/Dasharo/dts-scripts;protocol=https;branch=main"
-SRCREV = "ad42bda608e1e1db4281b1d263f265f44300ee4e"
+SRCREV = "4fad7cf3a193e692a5eb55a360f689c7a741a22c"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Also migrate most user confirmation to single function to simplify testing and remove code duplication. This results in those questions not accepting default value (most of those didn't accept any default anyway), and unifying possible choice to always display '[y|n]' with no variation (e.g. '(y/n)')